### PR TITLE
Display all transactions grouped by transaction hash

### DIFF
--- a/Shared (App and Extension)/WalletManager+Core.swift
+++ b/Shared (App and Extension)/WalletManager+Core.swift
@@ -19,9 +19,9 @@ extension WalletManager: SafariWalletCoreDelegate {
     func client() -> EthereumClient? {
         let key: String
         if case .ropsten = defaultNetwork {
-            key = alchemyRopstenKey
+            key = ApiKeys.alchemyRopsten
         } else {
-            key = alchemyMainnetKey
+            key = ApiKeys.alchemyMainnet
         }
         return AlchemyClient(network: defaultNetwork, key: key)
     }

--- a/Shared (App)/DeveloperTab/DeveloperView.swift
+++ b/Shared (App)/DeveloperTab/DeveloperView.swift
@@ -52,38 +52,6 @@ struct DeveloperView: View {
                     }
                 }
             }
-           
-            Button("Call alchemy_getAssetTransfers") {
-                Task {
-                    do {
-                        let client = AlchemyClient(key: ApiKeys.alchemyMainnet)!
-                        //https://docs.alchemy.com/alchemy/documentation/enhanced-apis/transfers-api
-                        let transfers = try await client.alchemyAssetTransfers(fromBlock: Block(rawValue: "A97AB8"),
-                                                                               toBlock: Block(rawValue: "A97CAC"),
-                                                                               fromAddress: Address(address: "3f5CE5FBFe3E9af3971dD833D26bA9b5C936f0bE"),
-                                                                               contractAddresses: [
-                                                                                Address(address: "7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9")!
-                                                                               ],
-                                                                               excludeZeroValue: true,
-                                                                               maxCount: 5)
-                        print(transfers)
-                    } catch {
-                        print(error)
-                    }
-                }
-            }
-            
-            Button("Call unmarshal_tokenTransactionsApi") {
-                Task {
-                  do {
-                      let client = UnmarshalClient(apiKey: ApiKeys.unmarshal)
-                      let transaction = try await client?.getTransactions(address: Address(raw: "ric.eth"))
-                      print(transaction)
-                  } catch {
-                     print(error)
-                  }
-               }
-            }
             
             Button("Create a new wallet") {
                 isOnBoardingPresented = true
@@ -104,12 +72,12 @@ struct DeveloperView: View {
             
             Text("Instantly creates a new wallet with the default password 'password123' and makes it the default wallet. Takes up to 5 seconds in debug mode.")
                 
-//            Button("Delete all wallets on disk", role: .destructive) {
-//                try? manager.deleteAllWallets()
-//                try? manager.deleteAllAddresses()
-//                countWallets()
-//            }
-//            .padding()
+            Button("Delete all wallets on disk", role: .destructive) {
+                try? manager.deleteAllWallets()
+                try? manager.deleteAllAddresses()
+                countWallets()
+            }
+            .padding()
             
         }
         .padding()

--- a/Shared (App)/DeveloperTab/DeveloperView.swift
+++ b/Shared (App)/DeveloperTab/DeveloperView.swift
@@ -42,7 +42,7 @@ struct DeveloperView: View {
             Button("get balance") {
                 Task {
                     do {
-                        let client = EthereumClient(provider: .alchemy(key: alchemyMainnetKey))!
+                        let client = EthereumClient(provider: .alchemy(key: ApiKeys.alchemyMainnet))!
                         let balance = try await client.ethGetBalance(address: "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B", blockNumber: .latest)
                         print(balance.description)
                         let height = try await client.ethBlockNumber()
@@ -56,7 +56,7 @@ struct DeveloperView: View {
             Button("Call alchemy_getAssetTransfers") {
                 Task {
                     do {
-                        let client = AlchemyClient(key: alchemyMainnetKey)!
+                        let client = AlchemyClient(key: ApiKeys.alchemyMainnet)!
                         //https://docs.alchemy.com/alchemy/documentation/enhanced-apis/transfers-api
                         let transfers = try await client.alchemyAssetTransfers(fromBlock: Block(rawValue: "A97AB8"),
                                                                                toBlock: Block(rawValue: "A97CAC"),
@@ -76,7 +76,7 @@ struct DeveloperView: View {
             Button("Call unmarshal_tokenTransactionsApi") {
                 Task {
                   do {
-                      let client = UnmarshalClient(covalentKey: unmarshalKey)
+                      let client = UnmarshalClient(apiKey: ApiKeys.unmarshal)
                       let transaction = try await client?.getTransactions(address: Address(raw: "ric.eth"))
                       print(transaction)
                   } catch {
@@ -104,12 +104,12 @@ struct DeveloperView: View {
             
             Text("Instantly creates a new wallet with the default password 'password123' and makes it the default wallet. Takes up to 5 seconds in debug mode.")
                 
-            Button("Delete all wallets on disk", role: .destructive) {
-                try? manager.deleteAllWallets()
-                try? manager.deleteAllAddresses()
-                countWallets()
-            }
-            .padding()
+//            Button("Delete all wallets on disk", role: .destructive) {
+//                try? manager.deleteAllWallets()
+//                try? manager.deleteAllAddresses()
+//                countWallets()
+//            }
+//            .padding()
             
         }
         .padding()

--- a/Shared (App)/Services/TransactionGroup.swift
+++ b/Shared (App)/Services/TransactionGroup.swift
@@ -36,11 +36,11 @@ struct TransactionGroup: Comparable, Identifiable {
     
     
     static func < (lhs: TransactionGroup, rhs: TransactionGroup) -> Bool {
-        guard let lhsBlock = lhs.transactions.first?.block,
-              let rhsBlock = rhs.transactions.first?.block else {
+        guard let lhsBlock = lhs.transactions.first?.block.intValue,
+              let rhsBlock = rhs.transactions.first?.block.intValue else {
                   return false
               }
-        return lhsBlock < rhsBlock
+        return lhsBlock > rhsBlock
     }
     
     static func == (lhs: TransactionGroup, rhs: TransactionGroup) -> Bool {

--- a/Shared (App)/Services/TransactionGroup.swift
+++ b/Shared (App)/Services/TransactionGroup.swift
@@ -7,11 +7,33 @@
 
 import Foundation
 import SafariWalletCore
+import MEWwalletKit
 
-struct TransactionGroup: Comparable {
-    
+struct TransactionGroup: Comparable, Identifiable {
+
     let transactionHash: String
     var transactions: [WalletTransaction]
+    
+    var id: String {
+        self.transactionHash
+    }
+    
+    var fromAddress: String {
+        return transactions.first?.from.address ?? "n/a"
+    }
+    
+    var toAddress: String {
+        return transactions.first?.to?.address ?? "n/a"
+    }
+    
+    var type: String {
+        return transactions.first?.type ?? "n/a"
+    }
+    
+    var value: String {
+        return transactions.first?.transactionValue ?? "n/a"
+    }
+    
     
     static func < (lhs: TransactionGroup, rhs: TransactionGroup) -> Bool {
         guard let lhsBlock = lhs.transactions.first?.block,

--- a/Shared (App)/Services/TransactionGroup.swift
+++ b/Shared (App)/Services/TransactionGroup.swift
@@ -1,0 +1,28 @@
+//
+//  TransactionGroup.swift
+//  Wallet
+//
+//  Created by Tassilo von Gerlach on 11/16/21.
+//
+
+import Foundation
+import SafariWalletCore
+
+struct TransactionGroup: Comparable {
+    
+    let transactionHash: String
+    var transactions: [WalletTransaction]
+    
+    static func < (lhs: TransactionGroup, rhs: TransactionGroup) -> Bool {
+        guard let lhsBlock = lhs.transactions.first?.block,
+              let rhsBlock = rhs.transactions.first?.block else {
+                  return false
+              }
+        return lhsBlock < rhsBlock
+    }
+    
+    static func == (lhs: TransactionGroup, rhs: TransactionGroup) -> Bool {
+        return lhs.transactionHash == rhs.transactionHash
+    }
+    
+}

--- a/Shared (App)/Services/TransactionService.swift
+++ b/Shared (App)/Services/TransactionService.swift
@@ -81,7 +81,10 @@ final class TransactionService: TransactionFetchable {
         return receivedTxs
     }
     
+    @MainActor
     func fetchTransactions(network: Network, address: Address) async throws -> [WalletTransactionType] {
+        //If Address is ENS only this method throws an error.
+        //SafariWalletCore.JsonRpcError(code: -32602, message: "Invalid string address in object param: fromAddress")
         async let alchemyOutgoingTransactions = self.alchemyClient!.alchemyAssetTransfers(fromBlock: .genesis,
                                                                                           toBlock: .latest,
                                                                                           fromAddress: address)

--- a/Shared (App)/Services/TransactionService.swift
+++ b/Shared (App)/Services/TransactionService.swift
@@ -103,6 +103,7 @@ final class TransactionService: TransactionFetchable {
         var hashGroup = [String: TransactionGroup]()
         for transaction in walletTransactions {
             if var group = hashGroup[transaction.hash] {
+                
                 group.transactions.append(transaction)
                 hashGroup[transaction.hash] = group
             } else {

--- a/Shared (App)/Services/TransactionService.swift
+++ b/Shared (App)/Services/TransactionService.swift
@@ -33,14 +33,16 @@ protocol TransactionFetchable {
 
 final class TransactionService: TransactionFetchable {
     
-    private let client: AlchemyClient? = AlchemyClient(key: alchemyMainnetKey)
+    private let alchemyClient: AlchemyClient? = AlchemyClient(key: ApiKeys.alchemyMainnet)
+    private let covalentClient: CovalentClient? = CovalentClient(apiKey: ApiKeys.covalent)
+    private let unmarshalClient: UnmarshalClient? = UnmarshalClient(apiKey: ApiKeys.unmarshal)
     
     @MainActor
     func fetchAllTransactions(chain: String,
                               address: String,
                               currency: String,
                               symbol: String) async throws -> [AlchemyAssetTransfer] {
-        guard let client = client else { throw TransactionError.networkConnectionFailed }
+        guard let client = alchemyClient else { throw TransactionError.networkConnectionFailed }
         let sentTxs = try await client.alchemyAssetTransfers(
             fromBlock: .genesis,
             fromAddress: Address(address: address)
@@ -57,10 +59,11 @@ final class TransactionService: TransactionFetchable {
                                address: String,
                                currency: String,
                                symbol: String) async throws -> [AlchemyAssetTransfer] {
-        guard let client = client else { throw TransactionError.networkConnectionFailed }
+        guard let client = alchemyClient else { throw TransactionError.networkConnectionFailed }
         let sentTxs = try await client.alchemyAssetTransfers(
             fromBlock: .genesis,
-            fromAddress: Address(address: address)
+            fromAddress: Address(address: address),
+            toAddress: Address(address: address)
         )
         return sentTxs
     }
@@ -70,13 +73,32 @@ final class TransactionService: TransactionFetchable {
                                    address: String,
                                    currency: String,
                                    symbol: String) async throws -> [AlchemyAssetTransfer] {
-        guard let client = client else { throw TransactionError.networkConnectionFailed }
+        guard let client = alchemyClient else { throw TransactionError.networkConnectionFailed }
         let receivedTxs = try await client.alchemyAssetTransfers(
             fromBlock: .genesis,
             toAddress: Address(address: address)
         )
         return receivedTxs
     }
+    
+    func fetchTransactions(network: Network, address: Address) async throws -> [WalletTransactionType] {
+        async let alchemyOutgoingTransactions = self.alchemyClient!.alchemyAssetTransfers(fromBlock: .genesis,
+                                                                                          toBlock: .latest,
+                                                                                          fromAddress: address)
+        async let alchemyIncomingTransactions = self.alchemyClient!.alchemyAssetTransfers(fromBlock: .genesis,
+                                                                                          toBlock: .latest,
+                                                                                          toAddress: address)
+        async let covalentTransactions = self.covalentClient!.getTransactions(network: .ethereum, address: address)
+        async let unmarshalTransactions = self.unmarshalClient!.getTransactions(address: address)
+
+        var walletTransaction =  [WalletTransaction]()
+        walletTransaction.append(contentsOf: try await alchemyOutgoingTransactions)
+        walletTransaction.append(contentsOf: try await alchemyIncomingTransactions)
+        walletTransaction.append(contentsOf: try await covalentTransactions)
+        walletTransaction.append(contentsOf: try await unmarshalTransactions)
+        return walletTransaction.map({ WalletTransactionType(transaction: $0) })
+    }
+    
 }
 
 enum TransactionError: Error {

--- a/Shared (App)/Services/TransactionService.swift
+++ b/Shared (App)/Services/TransactionService.swift
@@ -83,8 +83,6 @@ final class TransactionService: TransactionFetchable {
     
     @MainActor
     func fetchTransactions(network: Network, address: Address) async throws -> [TransactionGroup] {
-        //If Address is ENS only this method throws an error.
-        //SafariWalletCore.JsonRpcError(code: -32602, message: "Invalid string address in object param: fromAddress")
         async let alchemyOutgoingTransactions = self.alchemyClient!.alchemyAssetTransfers(fromBlock: .genesis,
                                                                                           toBlock: .latest,
                                                                                           fromAddress: address)

--- a/Shared (App)/Services/WalletTransaction.swift
+++ b/Shared (App)/Services/WalletTransaction.swift
@@ -1,0 +1,100 @@
+//
+//  WalletTransaction.swift
+//  Wallet
+//
+//  Created by Tassilo von Gerlach on 11/16/21.
+//
+
+import Foundation
+import MEWwalletKit
+import SafariWalletCore
+
+protocol WalletTransaction {
+    var from: Address { get }
+    var to: Address { get }
+    var type: String { get }
+    var value: String { get }
+    var source: String { get }
+}
+
+
+struct WalletTransactionType: Identifiable {
+
+    let transaction: WalletTransaction
+    let id = UUID()
+    
+}
+
+extension AlchemyAssetTransfer: WalletTransaction {
+    
+    var to: Address {
+        Address(raw: "hello.world")
+    }
+    
+    var from: Address {
+        Address(raw: "hello.world")
+    }
+    
+    var type: String {
+        "Type"
+    }
+    
+    var value: String {
+        "Value"
+    }
+    
+    var source: String {
+        "Source"
+    }
+    
+    
+    
+}
+
+extension Unmarshal.TokenTransaction: WalletTransaction {
+    
+    var to: Address {
+        Address(raw: "hello.world")
+    }
+    
+    var from: Address {
+        Address(raw: "hello.world")
+    }
+    
+    var type: String {
+        "Type"
+    }
+    
+    var value: String {
+        "Value"
+    }
+    
+    var source: String {
+        "Source"
+    }
+    
+}
+
+extension Covalent.Transaction: WalletTransaction {
+    
+    var to: Address {
+        Address(raw: "hello.world")
+    }
+    
+    var from: Address {
+        Address(raw: "hello.world")
+    }
+    
+    var type: String {
+        "Type"
+    }
+    
+    var value: String {
+        "Value"
+    }
+    
+    var source: String {
+        "Source"
+    }
+    
+}

--- a/Shared (App)/Services/WalletTransaction.swift
+++ b/Shared (App)/Services/WalletTransaction.swift
@@ -11,29 +11,15 @@ import SafariWalletCore
 
 protocol WalletTransaction {
     var from: Address { get }
-    var to: Address { get }
-    var type: String { get }
-    var value: String { get }
+    var to: Address? { get }
+    var type: String? { get }
+    var transactionValue: String? { get }
     var source: String { get }
     
     var hash: String { get }
     var block: Block { get }
     
     var underlyingObject: Any { get}
-}
-
-
-struct WalletTransactionType: Identifiable {
-
-    let transaction: WalletTransaction
-    let id = UUID()
-    
-}
-
-struct WalletTransactionV2 {
-    
-    
-    
 }
 
 extension AlchemyAssetTransfer: WalletTransaction {   
@@ -46,24 +32,20 @@ extension AlchemyAssetTransfer: WalletTransaction {
         self
     }
     
-    var to: Address {
-        Address(raw: "hello.world")
+    var type: String? {
+        self.category?.rawValue
     }
     
-    var from: Address {
-        Address(raw: "hello.world")
-    }
-    
-    var type: String {
-        "Type"
-    }
-    
-    var value: String {
-        "Value"
+    var transactionValue: String? {
+        if let value = self.value {
+            return String(value)
+        } else {
+            return nil
+        }
     }
     
     var source: String {
-        "Source"
+        "Alchemy"
     }
     
 }
@@ -78,24 +60,12 @@ extension Unmarshal.TokenTransaction: WalletTransaction {
         self
     }
     
-    var to: Address {
-        Address(raw: "hello.world")
-    }
-    
-    var from: Address {
-        Address(raw: "hello.world")
-    }
-    
-    var type: String {
-        "Type"
-    }
-    
-    var value: String {
-        "Value"
+    var transactionValue: String? {
+        self.value
     }
     
     var source: String {
-        "Source"
+        "Unmarshal"
     }
     
 }
@@ -114,24 +84,24 @@ extension Covalent.Transaction: WalletTransaction {
         return tx_hash
     }
     
-    var to: Address {
-        Address(raw: "hello.world")
+    var to: Address? {
+        self.to_address
     }
     
     var from: Address {
-        Address(raw: "hello.world")
+        self.from_address
     }
     
-    var type: String {
-        "Type"
+    var type: String? {
+        nil
     }
     
-    var value: String {
-        "Value"
+    var transactionValue: String? {
+        self.value
     }
     
     var source: String {
-        "Source"
+        "Covalent"
     }
     
 }

--- a/Shared (App)/Services/WalletTransaction.swift
+++ b/Shared (App)/Services/WalletTransaction.swift
@@ -15,6 +15,11 @@ protocol WalletTransaction {
     var type: String { get }
     var value: String { get }
     var source: String { get }
+    
+    var hash: String { get }
+    var block: Block { get }
+    
+    var underlyingObject: Any { get}
 }
 
 
@@ -25,7 +30,21 @@ struct WalletTransactionType: Identifiable {
     
 }
 
-extension AlchemyAssetTransfer: WalletTransaction {
+struct WalletTransactionV2 {
+    
+    
+    
+}
+
+extension AlchemyAssetTransfer: WalletTransaction {   
+    
+    var block: Block {
+        return self.blockNum
+    }
+    
+    var underlyingObject: Any {
+        self
+    }
     
     var to: Address {
         Address(raw: "hello.world")
@@ -47,11 +66,17 @@ extension AlchemyAssetTransfer: WalletTransaction {
         "Source"
     }
     
-    
-    
 }
 
 extension Unmarshal.TokenTransaction: WalletTransaction {
+    
+    var block: Block {
+        return Block(rawValue: self.blockNumber)
+    }
+    
+    var underlyingObject: Any {
+        self
+    }
     
     var to: Address {
         Address(raw: "hello.world")
@@ -76,6 +101,18 @@ extension Unmarshal.TokenTransaction: WalletTransaction {
 }
 
 extension Covalent.Transaction: WalletTransaction {
+    
+    var underlyingObject: Any {
+        self
+    }
+    
+    var block: Block {
+        return Block(rawValue: self.block_height)
+    }
+    
+    var hash: String {
+        return tx_hash
+    }
     
     var to: Address {
         Address(raw: "hello.world")

--- a/Shared (App)/TransactionsTab/TransactionDetailsView.swift
+++ b/Shared (App)/TransactionsTab/TransactionDetailsView.swift
@@ -1,0 +1,101 @@
+//
+//  TransactionDetailsView.swift
+//  Wallet
+//
+//  Created by Tassilo von Gerlach on 11/17/21.
+//
+
+import SwiftUI
+import SafariWalletCore
+
+struct TransactionDetailsView: View {
+    
+    let group: TransactionGroup
+
+    var body: some View {
+        List {
+            ForEach(group.transactions, id: \.source) { transaction in
+                if let alchemyTransfer = transaction as? AlchemyAssetTransfer {
+                    VStack {
+                        Text(alchemyTransfer.source).font(.title)
+                        Text(alchemyTransfer.description)
+                    }
+                } else if let covalentTransaction = transaction as? Covalent.Transaction {
+                    VStack {
+                        Text(covalentTransaction.source).font(.title)
+                        Text(covalentTransaction.description)
+                    }
+                } else if let unmarshalTransaction = transaction as? Unmarshal.TokenTransaction {
+                    VStack {
+                        Text(unmarshalTransaction.source).font(.title)
+                        Text(unmarshalTransaction.description)
+                    }
+                }
+            }
+        }
+    }
+    
+}
+
+extension AlchemyAssetTransfer: CustomStringConvertible {
+    
+    public var description: String {
+        return """
+        Block number: \(self.blockNum)
+        Hash: \(self.hash)
+        From: \(self.from.address)
+        To: \(self.to?.address ?? "n/a")
+        Value: \(String(describing: self.value))
+        Erc721TokenId: \(self.erc721TokenId ?? "n/a")
+        Asset: \(self.asset ?? "n/a")
+        Category: \(String(describing: self.category))
+        RawContract: \(String(describing: self.rawContract))
+        """
+    }
+    
+}
+
+extension Covalent.Transaction: CustomStringConvertible {
+    
+    public var description: String {
+        return """
+        Block height: \(self.block_height)
+        Hash: \(self.tx_hash)
+        Signed At: \(self.block_signed_at)
+        From: \(self.from_address)
+        From Address Label: \(self.from_address_label ?? "n/a")
+        To: \(self.to?.address ?? "n/a")
+        To Address Label: \(self.to_address_label ?? "n/a")
+        Offset: \(String(describing: self.tx_offset))
+        Successful: \(String(describing: self.successful))
+        Value: \(self.value ?? "n/a")
+        Value Quote: \(String(describing: self.value_quote))
+        Gas Offered: \(String(describing: self.gas_offered))
+        Gas Spent: \(String(describing: self.gas_spent))
+        Gas Price: \(String(describing: self.gas_price))
+        Gas Quote: \(String(describing: self.gas_quote))
+        Gas Quote Rate: \(String(describing: self.gas_quote_rate))
+        Log events: \(String(describing: self.log_events))
+        """
+    }
+    
+}
+
+extension Unmarshal.TokenTransaction: CustomStringConvertible {
+    
+    public var description: String {
+        return """
+        Block number: \(self.blockNumber)
+        Hash: \(self.hash)
+        From: \(self.from.address)
+        To: \(self.to?.address ?? "n/a")
+        Value: \(self.value)
+        Fee: \(self.fee)
+        Date: \(self.date)
+        Type: \(self.type ?? "n/a")
+        Status: \(self.status)
+        Description: \(self.details)
+        """
+    }
+    
+}

--- a/Shared (App)/TransactionsTab/TransactionsView.swift
+++ b/Shared (App)/TransactionsTab/TransactionsView.swift
@@ -12,37 +12,41 @@ struct TransactionsView: View {
     @ObservedObject var viewModel: TransactionsListViewModel
     
     var body: some View {
-        VStack {
-            Section {
-                Picker("Mode", selection: $viewModel.filter, content: {
-                    Text("All").tag(TransactionFilter.all)
-                    Text("Sent").tag(TransactionFilter.sent)
-                    Text("Received").tag(TransactionFilter.received)
-                    Text("Interactions").tag(TransactionFilter.interactions)
-                    Text("Failed").tag(TransactionFilter.failed)
-                })
-                    .pickerStyle(SegmentedPickerStyle())
-                List {
-                    switch viewModel.state {
-                    case .loading:
-                        ForEach(1..<6) { transactionGroup in
-//                            TransactionRow(tx: .placeholder)
-//                                .redacted(reason: .placeholder)
+        NavigationView {
+            VStack {
+                Section {
+                    Picker("Mode", selection: $viewModel.filter, content: {
+                        Text("All").tag(TransactionFilter.all)
+                        Text("Sent").tag(TransactionFilter.sent)
+                        Text("Received").tag(TransactionFilter.received)
+                        Text("Interactions").tag(TransactionFilter.interactions)
+                        Text("Failed").tag(TransactionFilter.failed)
+                    })
+                        .pickerStyle(SegmentedPickerStyle())
+                    List {
+                        switch viewModel.state {
+                            case .loading:
+                                ForEach(1..<6) { transactionGroup in
+                                    //                            TransactionRow(tx: .placeholder)
+                                    //                                .redacted(reason: .placeholder)
+                                }
+                            case .fetched(txs: let txs):
+                                ForEach(txs) { transactionGroup in
+                                    NavigationLink(destination: TransactionDetailsView(group: transactionGroup)) {
+                                        TransactionRow(transactionGroup: transactionGroup)
+                                    }
+                                }
+                            case .error(message: let message):
+                                // Simple error msg for now
+                                Text(message)
+                                Spacer()
                         }
-                    case .fetched(txs: let txs):
-                        ForEach(txs) { transactionGroup in
-                            TransactionRow(transactionGroup: transactionGroup)
-                        }
-                    case .error(message: let message):
-                        // Simple error msg for now
-                        Text(message)
-                        Spacer()
+                    }
+                    .refreshable {
+                        viewModel.fetchTransactions()
                     }
                 }
-                .refreshable {
-                    viewModel.fetchTransactions()
-                }
-            }
+            }.navigationBarHidden(true)
         }
     }
 }

--- a/Shared (App)/TransactionsTab/TransactionsView.swift
+++ b/Shared (App)/TransactionsTab/TransactionsView.swift
@@ -18,20 +18,20 @@ struct TransactionsView: View {
                     Text("All").tag(TransactionFilter.all)
                     Text("Sent").tag(TransactionFilter.sent)
                     Text("Received").tag(TransactionFilter.received)
-                    //                        Text("Interactions").tag(TransactionFilter.interactions)
-                    //                        Text("Failed").tag(TransactionFilter.failed)
+                    Text("Interactions").tag(TransactionFilter.interactions)
+                    Text("Failed").tag(TransactionFilter.failed)
                 })
                     .pickerStyle(SegmentedPickerStyle())
                 List {
                     switch viewModel.state {
                     case .loading:
-                        ForEach(1..<6) { tx in
+                        ForEach(1..<6) { transactionGroup in
 //                            TransactionRow(tx: .placeholder)
 //                                .redacted(reason: .placeholder)
                         }
                     case .fetched(txs: let txs):
-                        ForEach(txs) { tx in
-                            TransactionRow(tx: tx)
+                        ForEach(txs) { transactionGroup in
+                            TransactionRow(transactionGroup: transactionGroup)
                         }
                     case .error(message: let message):
                         // Simple error msg for now
@@ -49,15 +49,15 @@ struct TransactionsView: View {
 
 struct TransactionRow: View {
     
-    let tx: WalletTransactionType
+    let transactionGroup: TransactionGroup
     
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Text("Tx type: \(tx.transaction.type)")
+            Text("Tx type: \(transactionGroup.type)")
                 .font(.headline)
                 .bold()
             HStack {
-                Text(tx.transaction.from.address)
+                Text(transactionGroup.fromAddress)
                     .lineLimit(1)
                     .truncationMode(.middle)
                 Spacer()
@@ -65,11 +65,11 @@ struct TransactionRow: View {
                     .foregroundColor(.blue)
                     .unredacted()
                 Spacer()
-                Text(tx.transaction.to.address)
+                Text(transactionGroup.toAddress)
                     .lineLimit(1)
                     .truncationMode(.middle)
             }
-            Text("\(tx.transaction.value) \("USD")")
+            Text("\(transactionGroup.value) \("USD")")
                 .font(.system(size: 24.0, weight: .bold, design: .rounded))
         }
         .frame(maxWidth: .infinity)

--- a/Shared (App)/TransactionsTab/TransactionsView.swift
+++ b/Shared (App)/TransactionsTab/TransactionsView.swift
@@ -26,8 +26,8 @@ struct TransactionsView: View {
                     switch viewModel.state {
                     case .loading:
                         ForEach(1..<6) { tx in
-                            TransactionRow(tx: .placeholder)
-                                .redacted(reason: .placeholder)
+//                            TransactionRow(tx: .placeholder)
+//                                .redacted(reason: .placeholder)
                         }
                     case .fetched(txs: let txs):
                         ForEach(txs) { tx in
@@ -49,15 +49,15 @@ struct TransactionsView: View {
 
 struct TransactionRow: View {
     
-    let tx: TransactionViewModel
+    let tx: WalletTransactionType
     
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Text("Tx type: \(tx.category)")
+            Text("Tx type: \(tx.transaction.type)")
                 .font(.headline)
                 .bold()
             HStack {
-                Text(tx.fromAddress)
+                Text(tx.transaction.from.address)
                     .lineLimit(1)
                     .truncationMode(.middle)
                 Spacer()
@@ -65,11 +65,11 @@ struct TransactionRow: View {
                     .foregroundColor(.blue)
                     .unredacted()
                 Spacer()
-                Text(tx.toAddress ?? "")
+                Text(tx.transaction.to.address)
                     .lineLimit(1)
                     .truncationMode(.middle)
             }
-            Text("\(tx.value) \(tx.asset)")
+            Text("\(tx.transaction.value) \("USD")")
                 .font(.system(size: 24.0, weight: .bold, design: .rounded))
         }
         .frame(maxWidth: .infinity)
@@ -79,6 +79,9 @@ struct TransactionRow: View {
 
 struct TransactionsView_Previews: PreviewProvider {
     static var previews: some View {
-        TransactionsView(viewModel: TransactionsListViewModel(chain: "1", address: "ric.eth", currency: "USD", symbol: "$"))
+        TransactionsView(viewModel: TransactionsListViewModel(chain: "1",
+                                                              address: "ric.eth",
+                                                              currency: "USD",
+                                                              symbol: "$"))
     }
 }

--- a/Shared (App)/TransactionsTab/TransactionsView.swift
+++ b/Shared (App)/TransactionsTab/TransactionsView.swift
@@ -53,9 +53,11 @@ struct TransactionRow: View {
     
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Text("Tx type: \(transactionGroup.type)")
+            Text("Hash: \(transactionGroup.transactionHash)")
                 .font(.headline)
                 .bold()
+                .lineLimit(1)
+                .truncationMode(.tail)
             HStack {
                 Text(transactionGroup.fromAddress)
                     .lineLimit(1)
@@ -69,8 +71,7 @@ struct TransactionRow: View {
                     .lineLimit(1)
                     .truncationMode(.middle)
             }
-            Text("\(transactionGroup.value) \("USD")")
-                .font(.system(size: 24.0, weight: .bold, design: .rounded))
+            Text("\(transactionGroup.transactions.count) sources")
         }
         .frame(maxWidth: .infinity)
         .padding()

--- a/Shared (App)/ViewModels/TransactionsViewModel.swift
+++ b/Shared (App)/ViewModels/TransactionsViewModel.swift
@@ -51,20 +51,28 @@ final class TransactionsListViewModel: ObservableObject {
                 switch self.filter {
                     case .all:
                         let transactions = try await self.service.fetchTransactions(network: .ethereum,
-                                                                                    address: Address(ethereumAddress: "0x225E9B54F41F44F42150b6aAA730Da5f2d23FAf2")!)
+                                                                                    address: Address(ethereumAddress: "0x1FF1af1934DF4e772F2A8a998FEA635704B77836")!)
                         state = .fetched(txs: transactions)
                     case .sent:
                         //TODO: Implement me!
-                        state = .error(message: "Not yet implemented!")
+                        DispatchQueue.main.async { [weak self] in
+                            self?.state = .error(message: "Not yet implemented!")
+                        }
                     case .received:
                         //TODO: Implement me!
-                        state = .error(message: "Not yet implemented!")
+                        DispatchQueue.main.async { [weak self] in
+                            self?.state = .error(message: "Not yet implemented!")
+                        }
                     case .interactions:
                         //TODO: Implement me!
-                        state = .error(message: "Not yet implemented!")
+                        DispatchQueue.main.async { [weak self] in
+                            self?.state = .error(message: "Not yet implemented!")
+                        }
                     case .failed:
                         //TODO: Implement me!
-                        state = .error(message: "Not yet implemented!")
+                        DispatchQueue.main.async { [weak self] in
+                            self?.state = .error(message: "Not yet implemented!")
+                        }
                 }
             } catch let error {
                 //TODO: Error handling / Define error cases and appropriate error messages

--- a/Shared (App)/ViewModels/TransactionsViewModel.swift
+++ b/Shared (App)/ViewModels/TransactionsViewModel.swift
@@ -40,7 +40,6 @@ final class TransactionsListViewModel: ObservableObject {
         self.currency = currency
         self.symbol = symbol
         self.service = service
-//        fetchTransactions()
         handleFilterChange()
     }
     

--- a/Shared (App)/ViewModels/TransactionsViewModel.swift
+++ b/Shared (App)/ViewModels/TransactionsViewModel.swift
@@ -50,6 +50,9 @@ final class TransactionsListViewModel: ObservableObject {
             do {
                 let transactions = try await self.service.fetchTransactions(network: .ethereum,
                                                                             address: Address(ethereumAddress: "0x225E9B54F41F44F42150b6aAA730Da5f2d23FAf2")!)
+                
+                
+                
                 print(transactions)
             } catch {
                 print(error)

--- a/Shared (App)/ViewModels/TransactionsViewModel.swift
+++ b/Shared (App)/ViewModels/TransactionsViewModel.swift
@@ -8,6 +8,7 @@
 import Combine
 import Foundation
 import SafariWalletCore
+import MEWwalletKit
 
 // TODO:
 // - Implement paging
@@ -26,27 +27,34 @@ final class TransactionsListViewModel: ObservableObject {
     private let address: String
     private let currency: String
     private let symbol: String
-    private let service: TransactionFetchable
+    private let service: TransactionService
     private var cancellables = Set<AnyCancellable>()
     
     init(chain: String,
          address: String,
          currency: String,
          symbol: String,
-         service: TransactionFetchable = TransactionService()) {
+         service: TransactionService = TransactionService()) {
         self.chain = chain
         self.address = address
         self.currency = currency
         self.symbol = symbol
         self.service = service
-        fetchTransactions()
+//        fetchTransactions()
         handleFilterChange()
     }
     
     func fetchTransactions() {
         state = .loading
-        
-        
+        Task {
+            do {
+                let transactions = try await self.service.fetchTransactions(network: .ethereum,
+                                                                            address: Address(ethereumAddress: "0x225E9B54F41F44F42150b6aAA730Da5f2d23FAf2")!)
+                print(transactions)
+            } catch {
+                print(error)
+            }
+        }
         
 //        Task {
 //            do {

--- a/Shared (App)/ViewModels/TransactionsViewModel.swift
+++ b/Shared (App)/ViewModels/TransactionsViewModel.swift
@@ -16,7 +16,7 @@ final class TransactionsListViewModel: ObservableObject {
     
     enum State {
         case loading
-        case fetched(txs: [WalletTransactionType])
+        case fetched(txs: [TransactionGroup])
         case error(message: String)
     }
     
@@ -46,57 +46,32 @@ final class TransactionsListViewModel: ObservableObject {
     
     func fetchTransactions() {
         state = .loading
+        
         Task {
             do {
-                let transactions = try await self.service.fetchTransactions(network: .ethereum,
-                                                                            address: Address(ethereumAddress: "0x225E9B54F41F44F42150b6aAA730Da5f2d23FAf2")!)
-                
-                
-                
-                print(transactions)
-            } catch {
-                print(error)
+                switch self.filter {
+                    case .all:
+                        let transactions = try await self.service.fetchTransactions(network: .ethereum,
+                                                                                    address: Address(ethereumAddress: "0x225E9B54F41F44F42150b6aAA730Da5f2d23FAf2")!)
+                        state = .fetched(txs: transactions)
+                    case .sent:
+                        //TODO: Implement me!
+                        state = .error(message: "Not yet implemented!")
+                    case .received:
+                        //TODO: Implement me!
+                        state = .error(message: "Not yet implemented!")
+                    case .interactions:
+                        //TODO: Implement me!
+                        state = .error(message: "Not yet implemented!")
+                    case .failed:
+                        //TODO: Implement me!
+                        state = .error(message: "Not yet implemented!")
+                }
+            } catch let error {
+                //TODO: Error handling / Define error cases and appropriate error messages
+                state = .error(message: error.localizedDescription)
             }
         }
-        
-//        Task {
-//            do {
-//                var transactions = [AlchemyAssetTransfer]()
-//
-//                switch self.filter {
-//                case .sent:
-//                    transactions = try await service.fetchSentTransactions(
-//                        chain: chain,
-//                        address: address,
-//                        currency: currency,
-//                        symbol: symbol
-//                    )
-//                case .received:
-//                    transactions = try await service.fetchReceivedTransactions(
-//                        chain: chain,
-//                        address: address,
-//                        currency: currency,
-//                        symbol: symbol
-//                    )
-//                default:
-//                    transactions = try await service.fetchAllTransactions(
-//                        chain: chain,
-//                        address: address,
-//                        currency: currency,
-//                        symbol: symbol
-//                    )
-//                }
-//
-//                let viewModels = transactions
-//                    .sorted { ($0.blockNum.intValue ?? 0) > ($1.blockNum.intValue ?? 0) }
-//                    .map(TransactionViewModel.init)
-//
-//                state = .fetched(txs: viewModels)
-//            } catch let error {
-//                //TODO: Error handling / Define error cases and appropriate error messages
-//                state = .error(message: error.localizedDescription)
-//            }
-//        }
     }
     
     func handleFilterChange() {
@@ -120,34 +95,34 @@ struct TransactionViewModel: Identifiable {
     let category: String
 }
 
-extension TransactionViewModel {
-
-    init(tx: AlchemyAssetTransfer) {
-        self.init(
-            hash: tx.hash,
-            blockNum: tx.blockNum.intValue.flatMap(String.init) ?? "",
-            fromAddress: tx.from.address,
-            toAddress: tx.to.address,
-            value: tx.value, // TODO: Handle formatting
-            erc721TokenId: tx.erc721TokenId,
-            asset: tx.asset ?? "",
-            category: tx.category?.rawValue ?? ""
-        )
-    }
-    
-    static var placeholder: TransactionViewModel {
-        .init(
-            hash: "",
-            blockNum: "",
-            fromAddress: "0x225e9b54f41f44f42150b6aaa730da5f2d23faf2",
-            toAddress: "0x225e9b54f41f44f42150b6aaa730da5f2d23faf2",
-            value: "0.0",
-            erc721TokenId: nil,
-            asset: "ETH",
-            category: "external"
-        )
-    }
-}
+//extension TransactionViewModel {
+//
+//    init(tx: AlchemyAssetTransfer) {
+//        self.init(
+//            hash: tx.hash,
+//            blockNum: tx.blockNum.intValue.flatMap(String.init) ?? "",
+//            fromAddress: tx.from.address,
+//            toAddress: tx.to.address,
+//            value: tx.value, // TODO: Handle formatting
+//            erc721TokenId: tx.erc721TokenId,
+//            asset: tx.asset ?? "",
+//            category: tx.category?.rawValue ?? ""
+//        )
+//    }
+//    
+//    static var placeholder: TransactionViewModel {
+//        .init(
+//            hash: "",
+//            blockNum: "",
+//            fromAddress: "0x225e9b54f41f44f42150b6aaa730da5f2d23faf2",
+//            toAddress: "0x225e9b54f41f44f42150b6aaa730da5f2d23faf2",
+//            value: "0.0",
+//            erc721TokenId: nil,
+//            asset: "ETH",
+//            category: "external"
+//        )
+//    }
+//}
 
 enum TransactionFilter: Int {
     case all

--- a/Shared (App)/ViewModels/TransactionsViewModel.swift
+++ b/Shared (App)/ViewModels/TransactionsViewModel.swift
@@ -15,7 +15,7 @@ final class TransactionsListViewModel: ObservableObject {
     
     enum State {
         case loading
-        case fetched(txs: [TransactionViewModel])
+        case fetched(txs: [WalletTransactionType])
         case error(message: String)
     }
     
@@ -45,44 +45,47 @@ final class TransactionsListViewModel: ObservableObject {
     
     func fetchTransactions() {
         state = .loading
-        Task {
-            do {
-                var transactions = [AlchemyAssetTransfer]()
-                
-                switch self.filter {
-                case .sent:
-                    transactions = try await service.fetchSentTransactions(
-                        chain: chain,
-                        address: address,
-                        currency: currency,
-                        symbol: symbol
-                    )
-                case .received:
-                    transactions = try await service.fetchReceivedTransactions(
-                        chain: chain,
-                        address: address,
-                        currency: currency,
-                        symbol: symbol
-                    )
-                default:
-                    transactions = try await service.fetchAllTransactions(
-                        chain: chain,
-                        address: address,
-                        currency: currency,
-                        symbol: symbol
-                    )
-                }
-                
-                let viewModels = transactions
-                    .sorted { ($0.blockNum.intValue ?? 0) > ($1.blockNum.intValue ?? 0) }
-                    .map(TransactionViewModel.init)
-                
-                state = .fetched(txs: viewModels)
-            } catch let error {
-                //TODO: Error handling / Define error cases and appropriate error messages
-                state = .error(message: error.localizedDescription)
-            }
-        }
+        
+        
+        
+//        Task {
+//            do {
+//                var transactions = [AlchemyAssetTransfer]()
+//
+//                switch self.filter {
+//                case .sent:
+//                    transactions = try await service.fetchSentTransactions(
+//                        chain: chain,
+//                        address: address,
+//                        currency: currency,
+//                        symbol: symbol
+//                    )
+//                case .received:
+//                    transactions = try await service.fetchReceivedTransactions(
+//                        chain: chain,
+//                        address: address,
+//                        currency: currency,
+//                        symbol: symbol
+//                    )
+//                default:
+//                    transactions = try await service.fetchAllTransactions(
+//                        chain: chain,
+//                        address: address,
+//                        currency: currency,
+//                        symbol: symbol
+//                    )
+//                }
+//
+//                let viewModels = transactions
+//                    .sorted { ($0.blockNum.intValue ?? 0) > ($1.blockNum.intValue ?? 0) }
+//                    .map(TransactionViewModel.init)
+//
+//                state = .fetched(txs: viewModels)
+//            } catch let error {
+//                //TODO: Error handling / Define error cases and appropriate error messages
+//                state = .error(message: error.localizedDescription)
+//            }
+//        }
     }
     
     func handleFilterChange() {
@@ -113,8 +116,8 @@ extension TransactionViewModel {
             hash: tx.hash,
             blockNum: tx.blockNum.intValue.flatMap(String.init) ?? "",
             fromAddress: tx.from.address,
-            toAddress: tx.to?.address,
-            value: String(tx.value ?? 0.0), // TODO: Handle formatting
+            toAddress: tx.to.address,
+            value: tx.value, // TODO: Handle formatting
             erc721TokenId: tx.erc721TokenId,
             asset: tx.asset ?? "",
             category: tx.category?.rawValue ?? ""

--- a/Wallet.xcodeproj/project.pbxproj
+++ b/Wallet.xcodeproj/project.pbxproj
@@ -54,6 +54,10 @@
 		3D977061273CEEA80014CAC7 /* TransactionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D97705E273CD4AE0014CAC7 /* TransactionService.swift */; };
 		3D977062273CEEA90014CAC7 /* TransactionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D97705E273CD4AE0014CAC7 /* TransactionService.swift */; };
 		4A19E6E0271E673C0096027F /* JsonRpcClientTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A19E6DF271E673C0096027F /* JsonRpcClientTest.swift */; };
+		4AAE2E61274400D500696FBE /* WalletTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AAE2E60274400D500696FBE /* WalletTransaction.swift */; };
+		4AAE2E62274400D500696FBE /* WalletTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AAE2E60274400D500696FBE /* WalletTransaction.swift */; };
+		4AAE2E63274400D500696FBE /* WalletTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AAE2E60274400D500696FBE /* WalletTransaction.swift */; };
+		4AAE2E64274400D500696FBE /* WalletTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AAE2E60274400D500696FBE /* WalletTransaction.swift */; };
 		F8124BB8271E03DF00F06D5D /* SigningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8124BB7271E03DF00F06D5D /* SigningTests.swift */; };
 		F8321B5927169A1D00F12938 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8321B5827169A1D00F12938 /* OnboardingView.swift */; };
 		F8321B5A27176EBE00F12938 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8321B5827169A1D00F12938 /* OnboardingView.swift */; };
@@ -227,6 +231,8 @@
 		275C299327117F7D00DA2773 /* ethereum */ = {isa = PBXFileReference; lastKnownFileType = folder; path = ethereum; sourceTree = "<group>"; };
 		3D97705E273CD4AE0014CAC7 /* TransactionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionService.swift; sourceTree = "<group>"; };
 		4A19E6DF271E673C0096027F /* JsonRpcClientTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JsonRpcClientTest.swift; sourceTree = "<group>"; };
+		4AAE2E5F2743EDB900696FBE /* core */ = {isa = PBXFileReference; lastKnownFileType = folder; name = core; path = ../core; sourceTree = "<group>"; };
+		4AAE2E60274400D500696FBE /* WalletTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletTransaction.swift; sourceTree = "<group>"; };
 		F8124BB7271E03DF00F06D5D /* SigningTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SigningTests.swift; sourceTree = "<group>"; };
 		F8321B5827169A1D00F12938 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		F8321B5B27176ED600F12938 /* ShowMnemonicView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowMnemonicView.swift; sourceTree = "<group>"; };
@@ -312,6 +318,7 @@
 		0A0E1E7F270687AA00061EA6 = {
 			isa = PBXGroup;
 			children = (
+				4AAE2E5F2743EDB900696FBE /* core */,
 				F8ABEEE227124C5D007F7D11 /* Wallet Extension (iOS).entitlements */,
 				F8ABEEE127124C30007F7D11 /* Wallet (iOS).entitlements */,
 				F8ABEF3A271297A3007F7D11 /* Shared (App and Extension) */,
@@ -445,6 +452,7 @@
 			isa = PBXGroup;
 			children = (
 				3D97705E273CD4AE0014CAC7 /* TransactionService.swift */,
+				4AAE2E60274400D500696FBE /* WalletTransaction.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -851,6 +859,7 @@
 				F8321B5C27176ED600F12938 /* ShowMnemonicView.swift in Sources */,
 				F8321B5F27176EE700F12938 /* ConfirmMnemonicView.swift in Sources */,
 				F8AD21EF2717B4B40059D754 /* RestoreWalletView.swift in Sources */,
+				4AAE2E61274400D500696FBE /* WalletTransaction.swift in Sources */,
 				F8AD21E92717B3420059D754 /* CreatePasswordView.swift in Sources */,
 				F8ABEECD27124A8C007F7D11 /* BiometricsAuthentication.swift in Sources */,
 				F8ABEF3227125EFA007F7D11 /* WalletApp.swift in Sources */,
@@ -892,6 +901,7 @@
 				F8321B5D27176ED600F12938 /* ShowMnemonicView.swift in Sources */,
 				F8321B6027176EE700F12938 /* ConfirmMnemonicView.swift in Sources */,
 				F8AD21F02717B4B40059D754 /* RestoreWalletView.swift in Sources */,
+				4AAE2E62274400D500696FBE /* WalletTransaction.swift in Sources */,
 				F8AD21EA2717B3420059D754 /* CreatePasswordView.swift in Sources */,
 				F8ABEED227124A8C007F7D11 /* FileObserver.swift in Sources */,
 				F8ABEEDE27124A8C007F7D11 /* KeychainPasswordItem.swift in Sources */,
@@ -921,6 +931,7 @@
 			files = (
 				0A0E1ED7270687AE00061EA6 /* SafariWebExtensionHandler.swift in Sources */,
 				F8ABEED327124A8C007F7D11 /* FileObserver.swift in Sources */,
+				4AAE2E63274400D500696FBE /* WalletTransaction.swift in Sources */,
 				F8ABEF4E27138E1D007F7D11 /* String.swift in Sources */,
 				3D977061273CEEA80014CAC7 /* TransactionService.swift in Sources */,
 				F8ABEF3B271297B3007F7D11 /* WalletManager.swift in Sources */,
@@ -943,6 +954,7 @@
 			files = (
 				0A0E1ED8270687AE00061EA6 /* SafariWebExtensionHandler.swift in Sources */,
 				F8ABEED427124A8C007F7D11 /* FileObserver.swift in Sources */,
+				4AAE2E64274400D500696FBE /* WalletTransaction.swift in Sources */,
 				F8ABEF4F27138E1D007F7D11 /* String.swift in Sources */,
 				3D977062273CEEA90014CAC7 /* TransactionService.swift in Sources */,
 				F8ABEF3C271297B3007F7D11 /* WalletManager.swift in Sources */,

--- a/Wallet.xcodeproj/project.pbxproj
+++ b/Wallet.xcodeproj/project.pbxproj
@@ -62,6 +62,10 @@
 		4AAE2E672744ADA600696FBE /* TransactionGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AAE2E652744ADA600696FBE /* TransactionGroup.swift */; };
 		4AAE2E682744ADA600696FBE /* TransactionGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AAE2E652744ADA600696FBE /* TransactionGroup.swift */; };
 		4AAE2E692744ADA600696FBE /* TransactionGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AAE2E652744ADA600696FBE /* TransactionGroup.swift */; };
+		4AAE2E6B2745EE8B00696FBE /* TransactionDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AAE2E6A2745EE8B00696FBE /* TransactionDetailsView.swift */; };
+		4AAE2E6C2745EE8B00696FBE /* TransactionDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AAE2E6A2745EE8B00696FBE /* TransactionDetailsView.swift */; };
+		4AAE2E6D2745EE8B00696FBE /* TransactionDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AAE2E6A2745EE8B00696FBE /* TransactionDetailsView.swift */; };
+		4AAE2E6E2745EE8B00696FBE /* TransactionDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AAE2E6A2745EE8B00696FBE /* TransactionDetailsView.swift */; };
 		F8124BB8271E03DF00F06D5D /* SigningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8124BB7271E03DF00F06D5D /* SigningTests.swift */; };
 		F8321B5927169A1D00F12938 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8321B5827169A1D00F12938 /* OnboardingView.swift */; };
 		F8321B5A27176EBE00F12938 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8321B5827169A1D00F12938 /* OnboardingView.swift */; };
@@ -238,6 +242,7 @@
 		4AAE2E5F2743EDB900696FBE /* core */ = {isa = PBXFileReference; lastKnownFileType = folder; name = core; path = ../core; sourceTree = "<group>"; };
 		4AAE2E60274400D500696FBE /* WalletTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletTransaction.swift; sourceTree = "<group>"; };
 		4AAE2E652744ADA600696FBE /* TransactionGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionGroup.swift; sourceTree = "<group>"; };
+		4AAE2E6A2745EE8B00696FBE /* TransactionDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionDetailsView.swift; sourceTree = "<group>"; };
 		F8124BB7271E03DF00F06D5D /* SigningTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SigningTests.swift; sourceTree = "<group>"; };
 		F8321B5827169A1D00F12938 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		F8321B5B27176ED600F12938 /* ShowMnemonicView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowMnemonicView.swift; sourceTree = "<group>"; };
@@ -506,6 +511,7 @@
 			isa = PBXGroup;
 			children = (
 				F8812B572719239700D1B231 /* TransactionsView.swift */,
+				4AAE2E6A2745EE8B00696FBE /* TransactionDetailsView.swift */,
 			);
 			path = TransactionsTab;
 			sourceTree = "<group>";
@@ -876,6 +882,7 @@
 				F8ABEEDD27124A8C007F7D11 /* KeychainPasswordItem.swift in Sources */,
 				F8ABEEC927124A8C007F7D11 /* Constants.swift in Sources */,
 				F88801CF273A392A00094849 /* SettingsView.swift in Sources */,
+				4AAE2E6B2745EE8B00696FBE /* TransactionDetailsView.swift in Sources */,
 				F8812B6227193E8B00D1B231 /* DeveloperView.swift in Sources */,
 				F8812B5E27192AA600D1B231 /* ShortcutItem.swift in Sources */,
 				F8321B622717768400F12938 /* SummaryView.swift in Sources */,
@@ -919,6 +926,7 @@
 				F8ABEF3627125F16007F7D11 /* ContentView.swift in Sources */,
 				F8ABEECE27124A8C007F7D11 /* BiometricsAuthentication.swift in Sources */,
 				F88801D0273A392A00094849 /* SettingsView.swift in Sources */,
+				4AAE2E6C2745EE8B00696FBE /* TransactionDetailsView.swift in Sources */,
 				F8812B6327193E8B00D1B231 /* DeveloperView.swift in Sources */,
 				F8812B5F27192AA600D1B231 /* ShortcutItem.swift in Sources */,
 				F8321B632717768400F12938 /* SummaryView.swift in Sources */,
@@ -949,6 +957,7 @@
 				F8C5B0042723BC5900B54FBD /* keys.swift in Sources */,
 				0A8BB796272E719800DFC647 /* TransactionsViewModel.swift in Sources */,
 				F8ABEEDB27124A8C007F7D11 /* WalletError.swift in Sources */,
+				4AAE2E6D2745EE8B00696FBE /* TransactionDetailsView.swift in Sources */,
 				F8ABEED727124A8C007F7D11 /* SharedDocument.swift in Sources */,
 				F8ABEF49271389F5007F7D11 /* NSFileCoordinator.swift in Sources */,
 				F84CFF29273842B200193E1B /* WalletManager+Core.swift in Sources */,
@@ -973,6 +982,7 @@
 				F8C5B0052723BC5900B54FBD /* keys.swift in Sources */,
 				0A8BB797272E719800DFC647 /* TransactionsViewModel.swift in Sources */,
 				F8ABEEDC27124A8C007F7D11 /* WalletError.swift in Sources */,
+				4AAE2E6E2745EE8B00696FBE /* TransactionDetailsView.swift in Sources */,
 				F8ABEED827124A8C007F7D11 /* SharedDocument.swift in Sources */,
 				F8ABEF4A271389F5007F7D11 /* NSFileCoordinator.swift in Sources */,
 				F84CFF2A273842B200193E1B /* WalletManager+Core.swift in Sources */,

--- a/Wallet.xcodeproj/project.pbxproj
+++ b/Wallet.xcodeproj/project.pbxproj
@@ -58,6 +58,10 @@
 		4AAE2E62274400D500696FBE /* WalletTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AAE2E60274400D500696FBE /* WalletTransaction.swift */; };
 		4AAE2E63274400D500696FBE /* WalletTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AAE2E60274400D500696FBE /* WalletTransaction.swift */; };
 		4AAE2E64274400D500696FBE /* WalletTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AAE2E60274400D500696FBE /* WalletTransaction.swift */; };
+		4AAE2E662744ADA600696FBE /* TransactionGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AAE2E652744ADA600696FBE /* TransactionGroup.swift */; };
+		4AAE2E672744ADA600696FBE /* TransactionGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AAE2E652744ADA600696FBE /* TransactionGroup.swift */; };
+		4AAE2E682744ADA600696FBE /* TransactionGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AAE2E652744ADA600696FBE /* TransactionGroup.swift */; };
+		4AAE2E692744ADA600696FBE /* TransactionGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AAE2E652744ADA600696FBE /* TransactionGroup.swift */; };
 		F8124BB8271E03DF00F06D5D /* SigningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8124BB7271E03DF00F06D5D /* SigningTests.swift */; };
 		F8321B5927169A1D00F12938 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8321B5827169A1D00F12938 /* OnboardingView.swift */; };
 		F8321B5A27176EBE00F12938 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8321B5827169A1D00F12938 /* OnboardingView.swift */; };
@@ -233,6 +237,7 @@
 		4A19E6DF271E673C0096027F /* JsonRpcClientTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JsonRpcClientTest.swift; sourceTree = "<group>"; };
 		4AAE2E5F2743EDB900696FBE /* core */ = {isa = PBXFileReference; lastKnownFileType = folder; name = core; path = ../core; sourceTree = "<group>"; };
 		4AAE2E60274400D500696FBE /* WalletTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletTransaction.swift; sourceTree = "<group>"; };
+		4AAE2E652744ADA600696FBE /* TransactionGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionGroup.swift; sourceTree = "<group>"; };
 		F8124BB7271E03DF00F06D5D /* SigningTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SigningTests.swift; sourceTree = "<group>"; };
 		F8321B5827169A1D00F12938 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		F8321B5B27176ED600F12938 /* ShowMnemonicView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowMnemonicView.swift; sourceTree = "<group>"; };
@@ -453,6 +458,7 @@
 			children = (
 				3D97705E273CD4AE0014CAC7 /* TransactionService.swift */,
 				4AAE2E60274400D500696FBE /* WalletTransaction.swift */,
+				4AAE2E652744ADA600696FBE /* TransactionGroup.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -849,6 +855,7 @@
 				F8812B5B271923A300D1B231 /* ShortcutView.swift in Sources */,
 				F8812B582719239700D1B231 /* TransactionsView.swift in Sources */,
 				F8ABEF3527125F16007F7D11 /* ContentView.swift in Sources */,
+				4AAE2E662744ADA600696FBE /* TransactionGroup.swift in Sources */,
 				F8812B4F2718B91E00D1B231 /* Intro2View.swift in Sources */,
 				F8812B4C2718B91600D1B231 /* Intro1View.swift in Sources */,
 				3D97705F273CD4AE0014CAC7 /* TransactionService.swift in Sources */,
@@ -891,6 +898,7 @@
 				F8812B5C271923A300D1B231 /* ShortcutView.swift in Sources */,
 				F8812B592719239700D1B231 /* TransactionsView.swift in Sources */,
 				F8ABEF3327125EFA007F7D11 /* WalletApp.swift in Sources */,
+				4AAE2E672744ADA600696FBE /* TransactionGroup.swift in Sources */,
 				F8812B502718B91E00D1B231 /* Intro2View.swift in Sources */,
 				F8812B4D2718B91600D1B231 /* Intro1View.swift in Sources */,
 				3D977060273CEEA80014CAC7 /* TransactionService.swift in Sources */,
@@ -933,6 +941,7 @@
 				F8ABEED327124A8C007F7D11 /* FileObserver.swift in Sources */,
 				4AAE2E63274400D500696FBE /* WalletTransaction.swift in Sources */,
 				F8ABEF4E27138E1D007F7D11 /* String.swift in Sources */,
+				4AAE2E682744ADA600696FBE /* TransactionGroup.swift in Sources */,
 				3D977061273CEEA80014CAC7 /* TransactionService.swift in Sources */,
 				F8ABEF3B271297B3007F7D11 /* WalletManager.swift in Sources */,
 				F8ABEECB27124A8C007F7D11 /* Constants.swift in Sources */,
@@ -956,6 +965,7 @@
 				F8ABEED427124A8C007F7D11 /* FileObserver.swift in Sources */,
 				4AAE2E64274400D500696FBE /* WalletTransaction.swift in Sources */,
 				F8ABEF4F27138E1D007F7D11 /* String.swift in Sources */,
+				4AAE2E692744ADA600696FBE /* TransactionGroup.swift in Sources */,
 				3D977062273CEEA90014CAC7 /* TransactionService.swift in Sources */,
 				F8ABEF3C271297B3007F7D11 /* WalletManager.swift in Sources */,
 				F8ABEECC27124A8C007F7D11 /* Constants.swift in Sources */,

--- a/Wallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Wallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -29,15 +29,6 @@
         }
       },
       {
-        "package": "SafariWalletCore",
-        "repositoryURL": "https://github.com/Safari-Wallet/core",
-        "state": {
-          "branch": "develop",
-          "revision": "d7c9459b69126ba4822d8c5f31db26eaa7ef31c2",
-          "version": null
-        }
-      },
-      {
         "package": "CryptoSwift",
         "repositoryURL": "https://github.com/krzyzanowskim/CryptoSwift.git",
         "state": {


### PR DESCRIPTION
This PR displays all transactions from `Covalent`, `Unmarshal`, and `Alchemy` on the transactions tab.

Each row groups all the transaction of the same hash and displays how many sources it has. When selecting a row it takes you to a screen that displays all the raw data returned by these transactions and their corresponding source.

There is lots of clean up to be done, but this should get us started with playing around with the various data sources.

![simulator_screenshot_BA7F52E3-19FB-4CF7-AC8E-483832916926](https://user-images.githubusercontent.com/18754377/142485864-6a37b5cf-7681-4179-bf51-6689f336bf26.png)

![simulator_screenshot_8CBEB1E3-116C-4E99-BD1D-02F2877B4A08](https://user-images.githubusercontent.com/18754377/142486051-d35da8bf-be4f-4379-bbe2-e8ab2dcae0a1.png)