### PR TITLE
Add license in package.json

### DIFF
--- a/Shared (App)/Shared (Extension)/Resources/package.json
+++ b/Shared (App)/Shared (Extension)/Resources/package.json
@@ -1,6 +1,7 @@
 {
     "name": "safari-wallet-extension",
     "version": "0.0.0",
+    "license": "GPL-3.0",
     "author": {
         "name": "Balance DAO"
     },


### PR DESCRIPTION
Fixes "No license field" warning

![image](https://user-images.githubusercontent.com/8790386/147357409-197dfbe8-3860-41da-a6c7-dc9ff80beb99.png)
