### PR TITLE
quick fix out of range error

### DIFF
--- a/Shared (App)/SettingsTab/SettingsView.swift
+++ b/Shared (App)/SettingsTab/SettingsView.swift
@@ -93,6 +93,7 @@ struct SettingsView: View {
             await viewModel.setup()
         }
         .onDisappear {
+            guard viewModel.bundleIndex < viewModel.bundles.count else { return }
             userSettings.bundle = viewModel.bundles[viewModel.bundleIndex]
             print("default address index: \(userSettings.bundle!.defaultAddressIndex)")
         }


### PR DESCRIPTION
@bejitono ran into an out of range exception in the viewModel. Added a simple range check in SettingsView. 

The root cause is likely the complexity of the viewModel. I'm not sure what the best way is to use view models in SwiftUI, this may be something we need to look into later.